### PR TITLE
add .gitattributes for github/linguist to correctly map languages in use  

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+application/assets/**/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 application/assets/**/* linguist-vendored
+application/*.html linguist-vendored


### PR DESCRIPTION
By [using special .gitattributes](https://github.com/github/linguist#using-gitattributes), we can properly represent this project as the languages it is, rather than mostly CSS.

Before: Wildly skewed towards CSS, HTML and JavaScript

<img width="988" alt="screenshot 2019-02-14 20 27 13" src="https://user-images.githubusercontent.com/2925048/52828481-fa0e9c80-3096-11e9-88c7-950bb427a569.png">

After: Correctly identified as mostly Shell, HCL, Dockerfile and Python

<img width="988" alt="screenshot 2019-02-14 20 27 00" src="https://user-images.githubusercontent.com/2925048/52828492-04c93180-3097-11e9-89ef-8b300850b43b.png">

