### PR TITLE
Make New Relic alerts optional

### DIFF
--- a/bin/clean-workspace.sh
+++ b/bin/clean-workspace.sh
@@ -22,4 +22,5 @@ export BASE_DIR
 cp "$BASE_DIR/env.sh.sample" "$BASE_DIR/env.sh"
 clean_root_owned_docker_files
 rm -rf "$BUILD_DIR"
+git clean -fdx
 mkdir "$BUILD_DIR"

--- a/bin/clean-workspace.sh
+++ b/bin/clean-workspace.sh
@@ -21,6 +21,5 @@ export BASE_DIR
 
 cp "$BASE_DIR/env.sh.sample" "$BASE_DIR/env.sh"
 clean_root_owned_docker_files
-rm -rf "$BUILD_DIR"
-git clean -fdx
+rm -rf "$BUILD_DIR" "$BASE_DIR/terraform/.terraform"
 mkdir "$BUILD_DIR"

--- a/terraform/newrelic.tf
+++ b/terraform/newrelic.tf
@@ -32,7 +32,7 @@ resource "newrelic_alert_condition" "spin-appdex" {
 
   condition_scope = "application"
 
-  count = "${length(var.newrelic_apm_entities) > 0 ? 1 : 0}"
+  count = "${length(var.newrelic_apm_entities) > 0 ? (var.newrelic_alerts ? 1 : 0) : 0}"
 }
 
 # Add a notification channel
@@ -45,7 +45,7 @@ resource "newrelic_alert_channel" "email" {
     include_json_attachment = "1"
   }
 
-  count = "${length(var.newrelic_alert_email) > 0 ? 1 : 0}"
+  count = "${length(var.newrelic_alert_email) > 0 ? (var.newrelic_alerts ? 1 : 0) : 0}"
 }
 
 # Link the channel to the policy

--- a/terraform/newrelic.tf
+++ b/terraform/newrelic.tf
@@ -53,7 +53,7 @@ resource "newrelic_alert_policy_channel" "alert_email" {
   policy_id  = "${newrelic_alert_policy.alert.id}"
   channel_id = "${newrelic_alert_channel.email.id}"
 
-  count = "${length(var.newrelic_alert_email) > 0 ? 1 : 0}"
+  count = "${length(var.newrelic_alert_email) > 0 ? (var.newrelic_alerts ? 1 : 0) : 0}"
 }
 
 # Add a dashboard

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -96,6 +96,12 @@ variable "newrelic_apm_entities" {
   default     = []
 }
 
+# You have to have a full-blown New Relic subscription in order to deal with Alerts
+variable "newrelic_alerts" {
+  description = "Enable New Relic alerts"
+  default     = false
+}
+
 variable "newrelic_runbook_url" {
   description = "New Relic runbook URL"
   default     = "https://github.com/ModusCreateOrg/devops-infra-demo/wiki/runbook"

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,5 +1,6 @@
 module "vpc" {
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc"
+  source = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
 
   name = "infra-demo-vpc"
 

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "~> v1.0"
 
   name = "infra-demo-vpc"


### PR DESCRIPTION
Without this, running Terraform will fail if you do not have a full paid (or trial) New Relic subscription and key configured.