### PR TITLE
DOPS-101 Add trussworks bootstrap to devops example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@
 .DS_Store
 .vagrant
 /env.sh
-/terraform/.terraform*
-/terraform/terraform.tfstate*
-/terraform/tf.plan
+/terraform/**/.terraform
+/terraform/**/terraform.tfstate*
+/terraform/**/tf.plan
 __pycache__
 build/
 tmp/

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ See the branch [demo-20180619](https://github.com/ModusCreateOrg/devops-infra-de
 See the branch [demo-20180926](https://github.com/ModusCreateOrg/devops-infra-demo/tree/demo-20180926) for the code for the demo for the [Continuous Delivery NYC talk _Managing Expensive or Destructive Operations in Jenkins CI_](https://www.meetup.com/ContinuousDeliveryNYC/events/254036209/). Slides from this presentation are on [SlideShare](https://www.slideshare.net/RichardBullingtonMcG/managing-expensive-or-destructive-operations-in-jenkins-ci).
 
 See the branch [demo-20181205](https://github.com/ModusCreateOrg/devops-infra-demo/tree/demo-20181205) for the code for the demo for the [Ansible NYC talk _Ansible Image Bakeries: Best Practices & Pitfalls_](https://www.meetup.com/Ansible-NYC/events/256728741/). Slides from this presentation are on [SlideShare](https://www.slideshare.net/RichardBullingtonMcG/ansible-image-bakeries-best-practices-and-pitfalls).
- 
+
 See the branch [demo-20190130](https://github.com/ModusCreateOrg/devops-infra-demo/tree/demo-20190130) for the code for the demo for the [Big Apple DevOps  talk _Monitoring and Alerting as code with Terraform and New Relic_](https://www.meetup.com/Big-Apple-DevOps/events/257744262/). Slides from this presentation are on [Slideshare](https://www.slideshare.net/RichardBullingtonMcG/monitoring-and-alerting-as-code-with-terraform-and-new-relic).
- 
+
 See the branch [demo-20191109](https://github.com/ModusCreateOrg/devops-infra-demo/tree/demo-20191109) for the code for the demo for the [BSidesCT 2019 talk _Extensible DevSecOps pipelines with Jenkins, Docker, Terraform, and a kitchen sink full of scanners_](https://bsidesct.org/schedule/). Slides from this presentation are on
 [Slideshare](https://www.slideshare.net/RichardBullingtonMcG/extensible-dev-secops-pipelines-with-jenkins-docker-terraform-and-a-kitchen-sink-full-of-scanners)
- 
+
 Instructions
 ------------
 
  To run the demo end to end, you will need:
- 
+
 * [AWS Account](https://aws.amazon.com/)
 * [Google Cloud Account](https://cloud.google.com/)
 * [Docker](https://docker.com/) (tested with 18.05.0-ce)
@@ -33,7 +33,7 @@ Instructions
 
 Optionally, you can use Vagrant to test ansible playbooks locally and Jenkins to orchestrate creation of AMIs in conjunction with GitHub branches and pull requests.
 
-You will also need to set a few environment variables. The method of doing so will vary from platform to platform. 
+You will also need to set a few environment variables. The method of doing so will vary from platform to platform.
 
 ```
 AWS_PROFILE
@@ -74,20 +74,14 @@ Install [Vagrant](https://www.vagrantup.com/). Change directory into the root of
 
 ### Terraform
 
-This Terraform setup stores its state in Amazon S3 and uses DynamoDB for locking. There is a bit of setup required to bootstrap that configuration. You can use [this repository](https://github.com/monterail/terraform-bootstrap-example) to use Terraform to do that bootstrap process. The `backend.tfvars` file in that repo should be modified as follows to work with this project:
+This Terraform setup stores its state in Amazon S3 and uses DynamoDB for locking. There is a bit of setup required to bootstrap the configuration. Check out `./terraform/bootstrap/README.md` to setup the resources required for backend.
 
-(Replace us-east-1 and XXXXXXXXXXXX with the AWS region and your account ID)
-```
-bucket = "tf-state.devops-infra-demo.us-east-1.XXXXXXXXXXXX"
-dynamodb_table = "TerraformStatelock-devops-infra-demo"
-key = "terraform.tfstate"
-profile = "terraform"
-region = "us-east-1"
-```
+If you override the default input values (by CLI or using a `.tfvars` file) for bootstrapping, please update the `terraform.backend` section in `./terraform/terraform.tf` to reflect that.
+
 You'll also need to modify the list of operators who can modify the object in the S3 bucket. Put in the IAM user names of the user into the `setup/variables.tf` file in that project. If your Jenkins instance uses an IAM role to grant access, give it a similar set of permissions to those granted on in the bucket policy to IAM users.
 
 These commands will then set up cloud resources using terraform:
- 
+
     cd terraform
     terraform init
     terraform get
@@ -112,7 +106,7 @@ The application loads an image from Google storage. To get it loading correctly,
 
 ### Auto Scaling Groups
 
-The application in this demo uses an AWS Auto Scaling Group in order to dynamically change the number of servers deployed in response to load. Two policies help guide how many instances are available: a CPU scaling policy that seeks to keep the average CPU load below 40% in the cluster, and a scheduled scaling policy that scales the entire cluster down to 0 instances at 02:00 UTC every night, to minimize the charges should you forget to destroy the cluster. If the cluster is scaled down to 0 instances, you will need to edit the Auto Scaling Group through the console, the CLI, or an API call to set the sizes to non-zero, for example 
+The application in this demo uses an AWS Auto Scaling Group in order to dynamically change the number of servers deployed in response to load. Two policies help guide how many instances are available: a CPU scaling policy that seeks to keep the average CPU load below 40% in the cluster, and a scheduled scaling policy that scales the entire cluster down to 0 instances at 02:00 UTC every night, to minimize the charges should you forget to destroy the cluster. If the cluster is scaled down to 0 instances, you will need to edit the Auto Scaling Group through the console, the CLI, or an API call to set the sizes to non-zero, for example
 
 ### Elastic Load Balancing
 

--- a/bin/common-terraform.sh
+++ b/bin/common-terraform.sh
@@ -51,10 +51,8 @@ function init_terraform() {
     #shellcheck disable=SC2086,SC2046
     $DOCKER_TERRAFORM init \
         -input="$INPUT_ENABLED" \
-        -backend-config bucket=tf-state.${PROJECT_NAME}.${AWS_DEFAULT_REGION}.$(get_aws_account_id) \
-        -backend-config dynamodb_table=TerraformStatelock-${PROJECT_NAME} \
-        -backend-config region=${AWS_DEFAULT_REGION} \
-        -backend-config encrypt=true
+        -backend-config region=${AWS_DEFAULT_REGION}
+
     # Generate an SSH keypair if none exists yet
     if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
         #shellcheck disable=SC2174

--- a/terraform/bootstrap/.terraform.lock.hcl
+++ b/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.27.0"
+  constraints = ">= 3.75.0, ~> 4.16"
+  hashes = [
+    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
+    "zh:0f5ade3801fec487641e4f7d81e28075b716c787772f9709cc2378d20f325791",
+    "zh:19ffa83be6b6765a4f821a17b8d260dd0f192a6c40765fa53ac65fd042cb1f65",
+    "zh:3ac89d33ff8ca75bdc42f31c63ce0018ffc66aa69917c18713e824e381950e4e",
+    "zh:81a199724e74992c8a029a968d211cb45277d95a2e88d0f07ec85127b6c6849b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2e2c851a37ef97bbccccd2e686b4d016abe207a7f56bff70b10bfdf8ed1cbfd",
+    "zh:baf844def338d77f8a3106b1411a1fe22e93a82e3dc51e5d33b766f741c4a6a3",
+    "zh:bc33137fae808f91da0a9de7031cbea77d0ee4eefb4d2ad6ab7f58cc2111a7ff",
+    "zh:c960ae2b33c8d3327f67a3db5ce1952315146d69dfc3f1b0922242e2b218eec8",
+    "zh:f3ea1a25797c79c035463a1188a6a42e131f391f3cb714975ce49ccd301cda07",
+    "zh:f7e77c871d38236e5fedee0086ff77ff396e88964348c794cf38e578fcc00293",
+    "zh:fb338d5dfafab907b8608bd66cad8ca9ae4679f8c62c2435c2056a38b719baa2",
+  ]
+}

--- a/terraform/bootstrap/README.md
+++ b/terraform/bootstrap/README.md
@@ -1,0 +1,44 @@
+# Modus Devops Demo Bootstrap
+
+This terraform module is used to bootstrap the backend for the `/terraform` project. It uses [trussworks/bootstrap/aws](https://github.com/trussworks/terraform-aws-bootstrap) module to create all the resources needed to enable terraform backend in AWS.
+
+## How to use
+
+```bash
+cd terraform/bootstrap
+terraform init
+terraform apply
+```
+
+This will generate output which looks like this:
+
+```
+backend_details = {
+  "dynamodb_table" = "moduscreate-devops-demo-state-lock"
+  "logging_bucket" = "moduscreate-devops-demo-tf-state-log-us-east-1"
+  "state_bucket" = "moduscreate-devops-demo-tf-state-us-east-1"
+}
+```
+
+It can then be used in the `terraform.backend` config of main project (not the bootstrap project).
+
+```terraform
+terraform {
+  # ... existing config
+
+  backend "s3" {
+    bucket = "moduscreate-devops-demo-tf-state-us-east-1"
+    key = "terraform-state.tfstate"
+    dynamodb_table = "moduscreate-devops-demo-state-lock"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+```
+
+## Inputs
+
+| Name            | Description                  | Default                 |
+|-----------------|------------------------------|-------------------------|
+| `aws_region`    | Amazon region to use         | us-east-1               |
+| `account_alias` | Prefix for backend resources | moduscreate-devops-demo |

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = "~> 1.2.0"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "bootstrap" {
+  source              = "trussworks/bootstrap/aws"
+
+  region              = var.aws_region
+  account_alias       = var.account_alias
+  dynamodb_table_name = "${var.account_alias}-state-lock"
+}
+
+data "aws_caller_identity" "current" {}
+
+output "account_id" {
+  value = "${data.aws_caller_identity.current.account_id}"
+}
+
+output "arn" {
+  value = "${data.aws_caller_identity.current.arn}"
+}
+
+output "user_id" {
+  value = "${data.aws_caller_identity.current.user_id}"
+}
+
+output "backend_details" {
+  description = "Details of the S3 bucket and DynamoDB tables created for backend"
+  value       = module.bootstrap
+}

--- a/terraform/bootstrap/terraform.tfstate
+++ b/terraform/bootstrap/terraform.tfstate
@@ -1,0 +1,1567 @@
+{
+  "version": 4,
+  "terraform_version": "1.2.7",
+  "serial": 181,
+  "lineage": "3466ed5e-b3d1-107e-19aa-0306c957a966",
+  "outputs": {
+    "account_id": {
+      "value": "587267277416",
+      "type": "string"
+    },
+    "arn": {
+      "value": "arn:aws:sts::587267277416:assumed-role/AWSReservedSSO_AdministratorAccess_f36dc38d21a01223/akash@moduscreate.com",
+      "type": "string"
+    },
+    "backend_details": {
+      "value": {
+        "dynamodb_table": "moduscreate-devops-demo-state-lock",
+        "logging_bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+        "state_bucket": "moduscreate-devops-demo-tf-state-us-east-1"
+      },
+      "type": [
+        "object",
+        {
+          "dynamodb_table": "string",
+          "logging_bucket": "string",
+          "state_bucket": "string"
+        }
+      ]
+    },
+    "user_id": {
+      "value": "AROAYRO63QJUDMIL2CDJT:akash@moduscreate.com",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_caller_identity",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "587267277416",
+            "arn": "arn:aws:sts::587267277416:assumed-role/AWSReservedSSO_AdministratorAccess_f36dc38d21a01223/akash@moduscreate.com",
+            "id": "587267277416",
+            "user_id": "AROAYRO63QJUDMIL2CDJT:akash@moduscreate.com"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap",
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "terraform_state_lock",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:us-east-1:587267277416:table/moduscreate-devops-demo-state-lock",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PROVISIONED",
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "moduscreate-devops-demo-state-lock",
+            "local_secondary_index": [],
+            "name": "moduscreate-devops-demo-state-lock",
+            "point_in_time_recovery": [
+              {
+                "enabled": false
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 2,
+            "replica": [],
+            "restore_date_time": null,
+            "restore_source_name": null,
+            "restore_to_latest_time": null,
+            "server_side_encryption": [
+              {
+                "enabled": true,
+                "kms_key_arn": "arn:aws:kms:us-east-1:587267277416:key/51417bc8-fc8d-42c0-8a6a-9cd96b202aba"
+              }
+            ],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "table_class": "",
+            "tags": {
+              "Automation": "Terraform",
+              "Name": "terraform-state-lock"
+            },
+            "tags_all": {
+              "Automation": "Terraform",
+              "Name": "terraform-state-lock"
+            },
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 2
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjYwMDAwMDAwMDAwMCwidXBkYXRlIjozNjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap",
+      "mode": "managed",
+      "type": "aws_iam_account_alias",
+      "name": "alias",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "account_alias": "moduscreate-devops-demo",
+            "id": "moduscreate-devops-demo"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "data",
+      "type": "aws_caller_identity",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "587267277416",
+            "arn": "arn:aws:sts::587267277416:assumed-role/AWSReservedSSO_AdministratorAccess_f36dc38d21a01223/akash@moduscreate.com",
+            "id": "587267277416",
+            "user_id": "AROAYRO63QJUDMIL2CDJT:akash@moduscreate.com"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "data",
+      "type": "aws_iam_policy_document",
+      "name": "supplemental_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "576074780",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"enforce-tls-requests-only\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:*\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*\",\n      \"Principal\": {\n        \"AWS\": \"*\"\n      },\n      \"Condition\": {\n        \"Bool\": {\n          \"aws:SecureTransport\": \"false\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"inventory-and-analytics\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*\",\n      \"Principal\": {\n        \"Service\": \"s3.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"ArnLike\": {\n          \"aws:SourceArn\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1\"\n        },\n        \"StringEquals\": {\n          \"aws:SourceAccount\": \"587267277416\",\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    }\n  ]\n}",
+            "override_json": null,
+            "override_policy_documents": null,
+            "policy_id": null,
+            "source_json": null,
+            "source_policy_documents": null,
+            "statement": [
+              {
+                "actions": [
+                  "s3:*"
+                ],
+                "condition": [
+                  {
+                    "test": "Bool",
+                    "values": [
+                      "false"
+                    ],
+                    "variable": "aws:SecureTransport"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "*"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*"
+                ],
+                "sid": "enforce-tls-requests-only"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [
+                  {
+                    "test": "ArnLike",
+                    "values": [
+                      "arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1"
+                    ],
+                    "variable": "aws:SourceArn"
+                  },
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "587267277416"
+                    ],
+                    "variable": "aws:SourceAccount"
+                  },
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "bucket-owner-full-control"
+                    ],
+                    "variable": "s3:x-amz-acl"
+                  }
+                ],
+                "effect": "Allow",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "s3.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*"
+                ],
+                "sid": "inventory-and-analytics"
+              }
+            ],
+            "version": "2012-10-17"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "data",
+      "type": "aws_partition",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "dns_suffix": "amazonaws.com",
+            "id": "aws",
+            "partition": "aws",
+            "reverse_dns_prefix": "com.amazonaws"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1",
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "bucket_domain_name": "moduscreate-devops-demo-tf-state-us-east-1.s3.amazonaws.com",
+            "bucket_prefix": null,
+            "bucket_regional_domain_name": "moduscreate-devops-demo-tf-state-us-east-1.s3.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [],
+            "tags": {
+              "Automation": "Terraform"
+            },
+            "tags_all": {
+              "Automation": "Terraform"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_acl",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_control_policy": [
+              {
+                "grant": [
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "richard+devopssandbox",
+                        "email_address": "",
+                        "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462",
+                        "type": "CanonicalUser",
+                        "uri": ""
+                      }
+                    ],
+                    "permission": "FULL_CONTROL"
+                  }
+                ],
+                "owner": [
+                  {
+                    "display_name": "richard+devopssandbox",
+                    "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462"
+                  }
+                ]
+              }
+            ],
+            "acl": "private",
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1,private"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_analytics_configuration",
+      "name": "private_analytics_config",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "filter": [],
+            "id": "moduscreate-devops-demo-tf-state-us-east-1:Analytics",
+            "name": "Analytics",
+            "storage_class_analysis": [
+              {
+                "data_export": [
+                  {
+                    "destination": [
+                      {
+                        "s3_bucket_destination": [
+                          {
+                            "bucket_account_id": "",
+                            "bucket_arn": "arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1",
+                            "format": "CSV",
+                            "prefix": "_AWSBucketAnalytics"
+                          }
+                        ]
+                      }
+                    ],
+                    "output_schema_version": "V_1"
+                  }
+                ]
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_lifecycle_configuration",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "rule": [
+              {
+                "abort_incomplete_multipart_upload": [
+                  {
+                    "days_after_initiation": 14
+                  }
+                ],
+                "expiration": [
+                  {
+                    "date": "",
+                    "days": 0,
+                    "expired_object_delete_marker": true
+                  }
+                ],
+                "filter": [
+                  {
+                    "and": [],
+                    "object_size_greater_than": "",
+                    "object_size_less_than": "",
+                    "prefix": "",
+                    "tag": []
+                  }
+                ],
+                "id": "abort-incomplete-multipart-upload",
+                "noncurrent_version_expiration": [
+                  {
+                    "newer_noncurrent_versions": "",
+                    "noncurrent_days": 365
+                  }
+                ],
+                "noncurrent_version_transition": [
+                  {
+                    "newer_noncurrent_versions": "",
+                    "noncurrent_days": 30,
+                    "storage_class": "STANDARD_IA"
+                  }
+                ],
+                "prefix": "",
+                "status": "Enabled",
+                "transition": []
+              },
+              {
+                "abort_incomplete_multipart_upload": [],
+                "expiration": [
+                  {
+                    "date": "",
+                    "days": 14,
+                    "expired_object_delete_marker": false
+                  }
+                ],
+                "filter": [
+                  {
+                    "and": [],
+                    "object_size_greater_than": "",
+                    "object_size_less_than": "",
+                    "prefix": "_AWSBucketInventory/",
+                    "tag": []
+                  }
+                ],
+                "id": "aws-bucket-inventory",
+                "noncurrent_version_expiration": [],
+                "noncurrent_version_transition": [],
+                "prefix": "",
+                "status": "Enabled",
+                "transition": []
+              },
+              {
+                "abort_incomplete_multipart_upload": [],
+                "expiration": [
+                  {
+                    "date": "",
+                    "days": 30,
+                    "expired_object_delete_marker": false
+                  }
+                ],
+                "filter": [
+                  {
+                    "and": [],
+                    "object_size_greater_than": "",
+                    "object_size_less_than": "",
+                    "prefix": "_AWSBucketAnalytics/",
+                    "tag": []
+                  }
+                ],
+                "id": "aws-bucket-analytics",
+                "noncurrent_version_expiration": [],
+                "noncurrent_version_transition": [],
+                "prefix": "",
+                "status": "Enabled",
+                "transition": []
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_logging",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "target_bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "target_grant": [],
+            "target_prefix": "s3/moduscreate-devops-demo-tf-state-us-east-1/"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_policy",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"enforce-tls-requests-only\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:*\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*\",\n      \"Principal\": {\n        \"AWS\": \"*\"\n      },\n      \"Condition\": {\n        \"Bool\": {\n          \"aws:SecureTransport\": \"false\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"inventory-and-analytics\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1/*\",\n      \"Principal\": {\n        \"Service\": \"s3.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"ArnLike\": {\n          \"aws:SourceArn\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-us-east-1\"\n        },\n        \"StringEquals\": {\n          \"aws:SourceAccount\": \"587267277416\",\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    }\n  ]\n}"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_policy_document.supplemental_policy",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "public_access_block",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "kms_master_key_id": "",
+                    "sse_algorithm": "AES256"
+                  }
+                ],
+                "bucket_key_enabled": false
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "private_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-us-east-1",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Enabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket.aws_s3_bucket.private_bucket",
+            "module.bootstrap.module.terraform_state_bucket.data.aws_iam_account_alias.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_acl.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_lifecycle_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_logging.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_policy.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_public_access_block.public_access_block",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_server_side_encryption_configuration.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket_versioning.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_caller_identity.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_elb_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_partition.current",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_redshift_service_account.main",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_region.current"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_caller_identity",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "587267277416",
+            "arn": "arn:aws:sts::587267277416:assumed-role/AWSReservedSSO_AdministratorAccess_f36dc38d21a01223/akash@moduscreate.com",
+            "id": "587267277416",
+            "user_id": "AROAYRO63QJUDMIL2CDJT:akash@moduscreate.com"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_elb_service_account",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::127311923021:root",
+            "id": "127311923021",
+            "region": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_iam_policy_document",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2517482211",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"cloudtrail-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"cloudtrail.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"cloudtrail-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudtrail/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"Service\": \"cloudtrail.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"cloudwatch-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"logs.us-east-1.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"cloudwatch-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudwatch/*\",\n      \"Principal\": {\n        \"Service\": \"logs.us-east-1.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"config-permissions-check\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"config.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"config-bucket-delivery\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/config/AWSLogs/587267277416/Config/*\",\n      \"Principal\": {\n        \"Service\": \"config.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"elb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/elb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::127311923021:root\"\n      }\n    },\n    {\n      \"Sid\": \"alb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/alb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::127311923021:root\"\n      }\n    },\n    {\n      \"Sid\": \"nlb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/nlb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"Service\": \"delivery.logs.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"nlb-logs-acl-check\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"delivery.logs.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"redshift-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/redshift/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::193672423079:user/logs\"\n      }\n    },\n    {\n      \"Sid\": \"redshift-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::193672423079:user/logs\"\n      }\n    },\n    {\n      \"Sid\": \"enforce-tls-requests-only\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:*\",\n      \"Resource\": [\n        \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/*\",\n        \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\"\n      ],\n      \"Principal\": {\n        \"AWS\": \"*\"\n      },\n      \"Condition\": {\n        \"Bool\": {\n          \"aws:SecureTransport\": \"false\"\n        }\n      }\n    }\n  ]\n}",
+            "override_json": null,
+            "override_policy_documents": null,
+            "policy_id": null,
+            "source_json": null,
+            "source_policy_documents": null,
+            "statement": [
+              {
+                "actions": [
+                  "s3:GetBucketAcl"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "cloudtrail.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1"
+                ],
+                "sid": "cloudtrail-logs-get-bucket-acl"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "bucket-owner-full-control"
+                    ],
+                    "variable": "s3:x-amz-acl"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "cloudtrail.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudtrail/AWSLogs/587267277416/*"
+                ],
+                "sid": "cloudtrail-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:GetBucketAcl"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "logs.us-east-1.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1"
+                ],
+                "sid": "cloudwatch-logs-get-bucket-acl"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "bucket-owner-full-control"
+                    ],
+                    "variable": "s3:x-amz-acl"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "logs.us-east-1.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudwatch/*"
+                ],
+                "sid": "cloudwatch-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:GetBucketAcl"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "config.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1"
+                ],
+                "sid": "config-permissions-check"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "bucket-owner-full-control"
+                    ],
+                    "variable": "s3:x-amz-acl"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "config.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/config/AWSLogs/587267277416/Config/*"
+                ],
+                "sid": "config-bucket-delivery"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "arn:aws:iam::127311923021:root"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/elb/AWSLogs/587267277416/*"
+                ],
+                "sid": "elb-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "arn:aws:iam::127311923021:root"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/alb/AWSLogs/587267277416/*"
+                ],
+                "sid": "alb-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [
+                  {
+                    "test": "StringEquals",
+                    "values": [
+                      "bucket-owner-full-control"
+                    ],
+                    "variable": "s3:x-amz-acl"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "delivery.logs.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/nlb/AWSLogs/587267277416/*"
+                ],
+                "sid": "nlb-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:GetBucketAcl"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "delivery.logs.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1"
+                ],
+                "sid": "nlb-logs-acl-check"
+              },
+              {
+                "actions": [
+                  "s3:PutObject"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "arn:aws:iam::193672423079:user/logs"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/redshift/*"
+                ],
+                "sid": "redshift-logs-put-object"
+              },
+              {
+                "actions": [
+                  "s3:GetBucketAcl"
+                ],
+                "condition": [],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "arn:aws:iam::193672423079:user/logs"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1"
+                ],
+                "sid": "redshift-logs-get-bucket-acl"
+              },
+              {
+                "actions": [
+                  "s3:*"
+                ],
+                "condition": [
+                  {
+                    "test": "Bool",
+                    "values": [
+                      "false"
+                    ],
+                    "variable": "aws:SecureTransport"
+                  }
+                ],
+                "effect": "Deny",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "*"
+                    ],
+                    "type": "AWS"
+                  }
+                ],
+                "resources": [
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1",
+                  "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/*"
+                ],
+                "sid": "enforce-tls-requests-only"
+              }
+            ],
+            "version": "2012-10-17"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_partition",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "dns_suffix": "amazonaws.com",
+            "id": "aws",
+            "partition": "aws",
+            "reverse_dns_prefix": "com.amazonaws"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_redshift_service_account",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::193672423079:user/logs",
+            "id": "193672423079",
+            "region": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "data",
+      "type": "aws_region",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "US East (N. Virginia)",
+            "endpoint": "ec2.us-east-1.amazonaws.com",
+            "id": "us-east-1",
+            "name": "us-east-1"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1",
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "bucket_domain_name": "moduscreate-devops-demo-tf-state-log-us-east-1.s3.amazonaws.com",
+            "bucket_prefix": null,
+            "bucket_regional_domain_name": "moduscreate-devops-demo-tf-state-log-us-east-1.s3.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [],
+            "tags": {
+              "Automation": "Terraform",
+              "Name": "moduscreate-devops-demo-tf-state-log-us-east-1"
+            },
+            "tags_all": {
+              "Automation": "Terraform",
+              "Name": "moduscreate-devops-demo-tf-state-log-us-east-1"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_acl",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_control_policy": [
+              {
+                "grant": [
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "",
+                        "email_address": "",
+                        "id": "",
+                        "type": "Group",
+                        "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                      }
+                    ],
+                    "permission": "READ_ACP"
+                  },
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "",
+                        "email_address": "",
+                        "id": "",
+                        "type": "Group",
+                        "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                      }
+                    ],
+                    "permission": "WRITE"
+                  },
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "richard+devopssandbox",
+                        "email_address": "",
+                        "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462",
+                        "type": "CanonicalUser",
+                        "uri": ""
+                      }
+                    ],
+                    "permission": "FULL_CONTROL"
+                  }
+                ],
+                "owner": [
+                  {
+                    "display_name": "richard+devopssandbox",
+                    "id": "79b41d0c5b37c5b0cb908b377824a4227dd1e1fa66f3e75eb79853a6e52ab462"
+                  }
+                ]
+              }
+            ],
+            "acl": "log-delivery-write",
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1,log-delivery-write"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_lifecycle_configuration",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "rule": [
+              {
+                "abort_incomplete_multipart_upload": [],
+                "expiration": [
+                  {
+                    "date": "",
+                    "days": 90,
+                    "expired_object_delete_marker": false
+                  }
+                ],
+                "filter": [
+                  {
+                    "and": [],
+                    "object_size_greater_than": "",
+                    "object_size_less_than": "",
+                    "prefix": "/*",
+                    "tag": []
+                  }
+                ],
+                "id": "expire_all_logs",
+                "noncurrent_version_expiration": [
+                  {
+                    "newer_noncurrent_versions": "",
+                    "noncurrent_days": 30
+                  }
+                ],
+                "noncurrent_version_transition": [],
+                "prefix": "",
+                "status": "Enabled",
+                "transition": []
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_policy",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"cloudtrail-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"cloudtrail.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"cloudtrail-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudtrail/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"Service\": \"cloudtrail.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"cloudwatch-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"logs.us-east-1.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"cloudwatch-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/cloudwatch/*\",\n      \"Principal\": {\n        \"Service\": \"logs.us-east-1.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"config-permissions-check\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"config.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"config-bucket-delivery\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/config/AWSLogs/587267277416/Config/*\",\n      \"Principal\": {\n        \"Service\": \"config.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"elb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/elb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::127311923021:root\"\n      }\n    },\n    {\n      \"Sid\": \"alb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/alb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::127311923021:root\"\n      }\n    },\n    {\n      \"Sid\": \"nlb-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/nlb/AWSLogs/587267277416/*\",\n      \"Principal\": {\n        \"Service\": \"delivery.logs.amazonaws.com\"\n      },\n      \"Condition\": {\n        \"StringEquals\": {\n          \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n        }\n      }\n    },\n    {\n      \"Sid\": \"nlb-logs-acl-check\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"Service\": \"delivery.logs.amazonaws.com\"\n      }\n    },\n    {\n      \"Sid\": \"redshift-logs-put-object\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:PutObject\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/redshift/*\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::193672423079:user/logs\"\n      }\n    },\n    {\n      \"Sid\": \"redshift-logs-get-bucket-acl\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:GetBucketAcl\",\n      \"Resource\": \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::193672423079:user/logs\"\n      }\n    },\n    {\n      \"Sid\": \"enforce-tls-requests-only\",\n      \"Effect\": \"Deny\",\n      \"Action\": \"s3:*\",\n      \"Resource\": [\n        \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1/*\",\n        \"arn:aws:s3:::moduscreate-devops-demo-tf-state-log-us-east-1\"\n      ],\n      \"Principal\": {\n        \"AWS\": \"*\"\n      },\n      \"Condition\": {\n        \"Bool\": {\n          \"aws:SecureTransport\": \"false\"\n        }\n      }\n    }\n  ]\n}"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs",
+            "module.bootstrap.module.terraform_state_bucket_logs.data.aws_iam_policy_document.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "public_access_block",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "kms_master_key_id": "",
+                    "sse_algorithm": "AES256"
+                  }
+                ],
+                "bucket_key_enabled": null
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.bootstrap.module.terraform_state_bucket_logs",
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "aws_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "expected_bucket_owner": "",
+            "id": "moduscreate-devops-demo-tf-state-log-us-east-1",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Disabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  description = "Amazon Region to use"
+  default     = "us-east-1"
+}
+
+variable "account_alias" {
+  description = "Prefix for backend resources"
+  default     = "moduscreate-devops-demo"
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -4,10 +4,10 @@ terraform {
   # ./bootstrap project. See ./bootstrap/README.md for details.
   #===================================================================
   backend "s3" {
-    bucket         = "moduscreate-devops-demo-tf-state-us-east-1"
+    bucket         = "${var.backend_account_alias}-tf-state-us-east-1"
     key            = "terraform-state.tfstate"
-    dynamodb_table = "moduscreate-devops-demo-state-lock"
-    region         = "us-east-1"
+    dynamodb_table = "${var.backend_account_alias}-state-lock"
+    region         = "${var.aws_region}"
     encrypt        = "true"
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,15 +1,14 @@
 terraform {
+  #===================================================================
+  # The S3 bucket and DyanmoDB table used here are created using
+  # ./bootstrap project. See ./bootstrap/README.md for details.
+  #===================================================================
   backend "s3" {
-    encrypt = true
-
-    # We can't specify parameterized config here but if we could it would look like:
-    # bucket = "tf-state.${project_name}.${aws_region}.${data.aws_caller_identity.current.account_id}"
-    # dynamodb_table = "TerraformStatelock-${project_name}"
-    bucket = "my-terraform-bucket"
-
-    dynamodb_table = "TerraformStatelock"
+    bucket         = "moduscreate-devops-demo-tf-state-us-east-1"
+    key            = "terraform-state.tfstate"
+    dynamodb_table = "moduscreate-devops-demo-state-lock"
     region         = "us-east-1"
-    key            = "terraform.tfstate"
+    encrypt        = "true"
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -111,3 +111,8 @@ variable "newrelic_alert_email" {
   description = "New Relic alert email"
   default     = ""
 }
+
+variable "backend_account_alias" {
+  description = "Account alias, or prefix, used by bootstrap project"
+  default     = "moduscreate-devops-demo"
+}


### PR DESCRIPTION
# Proposed Changes

After research, I've found https://github.com/trussworks/terraform-aws-bootstrap to be the easiest solution for bootstrapping Terraform projects. Using this module, we can add the bootstrap infrastructure to the repo and manage it going forward.

## How it works

The bootstrap module has a local backend. We need to first apply the bootstrap module to generate the resources like S3 bucket, DynamoDB table etc.

These resources can then be used in the backend of main Terraform project.

✅ Add bootstrap project
✅ Updated `README.md` with new setup instructions for Terraform project
✅ Added the bootstrap state to the repo. This makes sure the terraform project is good to go without bootstrapping (if using default aliases and prefix)